### PR TITLE
Add missing requirements so pip install works from a fresh setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     packages=find_packages('src'),
     package_dir={'': 'src'},
     py_modules=[path.stem for path in Path('src').glob('*.py')],
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     zip_safe=True,
     include_package_data=True,
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         'numpy==1.20.1',
         'pyarrow==3.0.0',
         'requests',
+        'tqdm',
     ],
     extras_require=dict(
         test=[

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         'pandas==1.2.2',
         'numpy==1.20.1',
         'pyarrow==3.0.0',
+        'requests',
     ],
     extras_require=dict(
         test=[


### PR DESCRIPTION
This PR updates the requirements in setup.py so that a `pip install` will work from a clean start.

Resolves https://github.com/councilofelders/opensignals/issues/4
