### PR TITLE
add feature prefix param

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,8 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+db/
+.idea/
+*.csv
+

--- a/src/opensignals/data/yahoo.py
+++ b/src/opensignals/data/yahoo.py
@@ -99,7 +99,8 @@ def get_data(
         db_dir,
         features_generators=None,
         last_friday=datetime.today() - relativedelta(weekday=FR(-1)),
-        target='target_20d'):
+        target='target_20d',
+        feature_prefix=None):
     """generate data set"""
 
     if features_generators is None:
@@ -120,7 +121,7 @@ def get_data(
 
     feature_names = []
     for features_generator in features_generators:
-        ticker_data, feature_names_aux = features_generator.generate_features(ticker_data)
+        ticker_data, feature_names_aux = features_generator.generate_features(ticker_data, feature_prefix)
         feature_names.extend(feature_names_aux)
 
     # merge our feature data with Numerai targets

--- a/src/opensignals/features.py
+++ b/src/opensignals/features.py
@@ -80,10 +80,14 @@ class RSI:
                              for step in self.steps[:-1]}
         return feat_quintile_lag, feat_rsi_diff, feat_rsi_diff_abs
 
-    def generate_features(self, ticker_data):
+    def generate_features(self, ticker_data, feature_prefix=None):
         # add Relative Strength Index
         logger.info(f'generating RSI {self.interval} for {self.variable}...')
+
         feature_prefix_name = f'RSI_{self.interval}_{self.variable}'
+        if feature_prefix:
+            feature_prefix_name = f'{feature_prefix}_RSI_{self.interval}_{self.variable}'
+
         ticker_groups = ticker_data.groupby('bloomberg_ticker')
         ticker_data[feature_prefix_name] = \
             ticker_groups[self.variable].transform(
@@ -161,10 +165,14 @@ class SMA:
                              for step in self.steps[:-1]}
         return feat_quintile_lag, feat_rsi_diff, feat_rsi_diff_abs
 
-    def generate_features(self, ticker_data):
+    def generate_features(self, ticker_data, feature_prefix=None):
         # add Relative Strength Index
         logger.info(f'generating SMA {self.interval} for {self.variable}...')
+
         feature_prefix_name = f'SMA_{self.interval}_{self.variable}'
+        if feature_prefix:
+            feature_prefix_name = f'{feature_prefix}_SMA_{self.interval}_{self.variable}'
+
         ticker_groups = ticker_data.groupby('bloomberg_ticker')
         ticker_data[feature_prefix_name] = \
             ticker_groups[self.variable].transform(


### PR DESCRIPTION
Adding a feature prefix param so we can filter column names using a string prefix. In the new Signals example script I want to do:

```
feature_names = train.filter(like='feature_').columns.to_list()
```
