### PR TITLE
update pyarrow to work on m1 mac

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 docopt==0.6.2
 pandas==1.2.2
-numpy==1.20.1
-pyarrow==3.0.0
+numpy==1.21.4
+pyarrow==6.0.1
 requests==2.25.1
 tqdm==4.61.2


### PR DESCRIPTION
Was setting up opensignals on M1 mac and the old version wouldn't install. I updated it to latest and ran the test script and everything still works