### PR TITLE
Fix Timestamp and str comparison

### DIFF
--- a/src/opensignals/data/provider.py
+++ b/src/opensignals/data/provider.py
@@ -221,9 +221,10 @@ class Provider(ABC):
             lambda x: ' '.join(x.yahoo.astype(str))
         )
         concat_dfs = []
-        for start_date, tickers in ticker_missing_grouped.iteritems():
-            temp_df = self.download_tickers(tickers.split(' '), start=start_date)
-
+        for start, tickers in ticker_missing_grouped.iteritems():
+            temp_df = self.download_tickers(tickers.split(' '), start=start)
+            start_date = dt.datetime.strptime(start, '%Y-%m-%d')
+            
             # Yahoo Finance returning previous day in some situations
             # (e.g. Friday in TelAviv markets)
             temp_df = temp_df[temp_df.date >= start_date]


### PR DESCRIPTION
Convert `str` with date into type `date` when needed